### PR TITLE
No cache filter implemented to fix 500 server error

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/ui/NoCacheFilter.java
+++ b/finish/src/main/java/io/openliberty/guides/ui/NoCacheFilter.java
@@ -1,0 +1,26 @@
+package io.openliberty.guides.ui.filters;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+
+@WebFilter(servletNames = { "Faces Servlet" })
+public class NoCacheFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+                HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+                httpServletResponse.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+                httpServletResponse.setDateHeader("Expires", 0);
+                httpServletResponse.setHeader("Pragma", "no-cache");
+                chain.doFilter(request, response);
+	}
+
+}

--- a/finish/src/main/webapp/welcome.html
+++ b/finish/src/main/webapp/welcome.html
@@ -5,7 +5,6 @@
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
-
   Contributors:
       IBM Corporation - initial API and implementation
 -->
@@ -29,6 +28,15 @@
           <input type="submit" name="Go" value="Go">
         </p>
       </form>
-
+      <script type="text/javascript">
+        // Force safari to refresh the page
+        // if a cached copy was loaded
+        // from the browser back-forward cache.
+        window.onpageshow = function(e) {
+          if (e.persisted) {
+            window.location.reload();
+          }
+        }
+      </script>
     </body>
 </html>

--- a/start/src/main/java/io/openliberty/guides/ui/NoCacheFilter.java
+++ b/start/src/main/java/io/openliberty/guides/ui/NoCacheFilter.java
@@ -1,0 +1,26 @@
+package io.openliberty.guides.ui.filters;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+
+@WebFilter(servletNames = { "Faces Servlet" })
+public class NoCacheFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+                HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+                httpServletResponse.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+                httpServletResponse.setDateHeader("Expires", 0);
+                httpServletResponse.setHeader("Pragma", "no-cache");
+                chain.doFilter(request, response);
+	}
+
+}

--- a/start/src/main/webapp/welcome.html
+++ b/start/src/main/webapp/welcome.html
@@ -5,7 +5,6 @@
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
-
   Contributors:
       IBM Corporation - initial API and implementation
 -->
@@ -29,6 +28,15 @@
           <input type="submit" name="Go" value="Go">
         </p>
       </form>
-
+      <script type="text/javascript">
+        // Force safari to refresh the page
+        // if a cached copy was loaded
+        // from the browser back-forward cache.
+        window.onpageshow = function(e) {
+          if (e.persisted) {
+            window.location.reload();
+          }
+        }
+      </script>
     </body>
 </html>


### PR DESCRIPTION
Implemented and tested behavior of No Cache Filter from JWT branch. 
I was unable to recreate the 500 server error from https://github.com/OpenLiberty/guide-security-intro/issues/70 after implementing the changes. 