### PR TITLE
specified app name directly in server.xml

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -22,7 +22,6 @@
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
-        <liberty.var.application.name>${project.artifactId}.war</liberty.var.application.name>
     </properties>
 
     <dependencies>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -19,9 +19,9 @@
   <include location="userRegistry.xml"/>
   <!-- end::location[]-->
 
-  <application location="${application.name}" type="war"
-               id="${application.name}"
-               name="${application.name}" context-root="/">
+  <application location="guide-security-intro.war" type="war"
+               id="guide-security-intro.war"
+               name="guide-security-intro.war" context-root="/">
     <!-- tag::application-bnd[] -->
     <application-bnd>
       <!-- tag::Security[] -->

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -9,7 +9,6 @@
 
   <variable name="default.http.port" defaultValue="9080"/>
   <variable name="default.https.port" defaultValue="9443"/>
-  <variable name="application.name" defaultValue="guide-security-intro.war"/>
 
   <httpEndpoint id="defaultHttpEndpoint"
     httpPort="${default.http.port}"

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -22,7 +22,6 @@
         <!-- Liberty configuration -->
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
-        <liberty.var.application.name>${project.artifactId}.war</liberty.var.application.name>
     </properties>
 
     <dependencies>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -8,7 +8,6 @@
 
   <variable name="default.http.port" defaultValue="9080"/>
   <variable name="default.https.port" defaultValue="9443"/>
-  <variable name="application.name" defaultValue="guide-security-intro.war"/>
 
   <httpEndpoint id="defaultHttpEndpoint"
     httpPort="${default.http.port}"

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -16,9 +16,9 @@
 
   <include location="userRegistry.xml"/>
 
-  <application location="${application.name}" type="war"
-               id="${application.name}"
-               name="${application.name}" context-root="/">
+  <application location="guide-security-intro.war" type="war"
+               id="guide-security-intro.war"
+               name="guide-security-intro.war" context-root="/">
     <application-bnd>
       <security-role name="admin">
         <group name="Manager" />


### PR DESCRIPTION
Fix for the following warning that would appear while running the server:
`[WARNING ] CWWKG0104W: The ID attribute with value ${application.name} for the configuration element application must have a fixed value. Variables in the ID attribute will not be replaced.`

- Specified the application name directly in `server.xml` instead of using ${application.name} 
- Removed `<liberty.var.application.name>` property from `pom.xml` as it is no longer used 